### PR TITLE
KPT振り返り機能の追加

### DIFF
--- a/src/kpt.js
+++ b/src/kpt.js
@@ -22,46 +22,41 @@ module.exports = (robot) => {
     let brainKeep = robot.brain.get('keep') || [];
     let brainProblem = robot.brain.get('problem') || [];
 
+    // 追加
+    const addItem = (brain, type, msg) => {
+        brain.push(msg);
+        res.send(`「${msg}」を${type}に追加したゴシ！`);
+    };
     robot.respond(/kpt k (.*)/i, (res) => {
         if (!mode) return false;
-
-        brainKeep.push(res.match[1]);
-        res.send(`「${res.match[1]}」をKEEPに追加したゴシ！`);
+        addItem(brainKeep, 'KEEP', res.match[1]);
     });
-
     robot.respond(/kpt p (.*)/i, (res) => {
         if (!mode) return false;
-
-        brainProblem.push(res.match[1]);
-        res.send(`「${res.match[1]}」をPROBLEMに追加したゴシ！`);
+        addItem(brainProblem, 'PROBLEM', res.match[1]);
     });
 
+    // 一覧の確認
+    const showList = (brain, type, emoji) => {
+        if (brain.length === 0) {
+            res.send('${type}はまだ0件だゴシ…。');
+        } else {
+            res.send('現在の${type}はこれだけ出てるゴシよ。');
+            brain.forEach(elm => {
+                res.send(`${emoji}「${elm}」`);
+            });
+        }
+    };
     robot.respond(/kpt list k/i, (res) => {
         if (!mode) return false;
-
-        if (brainKeep.length === 0) {
-            res.send('KEEPはまだ0件だゴシ…。');
-        } else {
-            res.send('現在のKEEPはこれだけ出てるゴシよ。');
-            brainKeep.forEach(elm => {
-                res.send(`:ok_woman:「${elm}」`);
-            });
-        }
+        showList(brainKeep, 'KEEP', ':ok_woman:');
     });
-
     robot.respond(/kpt list p/i, (res) => {
         if (!mode) return false;
-
-        if (brainKeep.length === 0) {
-            res.send('PROBLEMはまだ0件だゴシ…。');
-        } else {
-            res.send('現在のPROBLEMはこれだけ出てるゴシよ。');
-            brainProblem.forEach(elm => {
-                res.send(`:no_good:「${elm}」`);
-            });
-        }
+        showList(brainProblem, 'PROBLEM', ':no_good:');
     });
 
+    // 一覧のクリア
     robot.respond(/kpt clear/i, (res) => {
         if (!mode) return false;
 

--- a/src/kpt.js
+++ b/src/kpt.js
@@ -6,11 +6,12 @@ module.exports = (robot) => {
 
     // KPTモードのON/OFF
     let mode = false;
-    robot.respond(/kptmode (.*)/i, (res) => {
-        if (res.match[0] === 'on') {
+    robot.respond(/kpt mode (.*)/i, (res) => {
+        console.log(res.match[0], res.match[1]);
+        if (res.match[1] === 'on') {
             mode = true;
             res.send('KPTモードがONになったゴシ！振り返るゴシ〜！');
-        } else if (res.match[0] === 'off') {
+        } else if (res.match[1] === 'off') {
             mode = false;
             res.send('KPTモードがOFFになったゴシ！お疲れ様ゴシ。');
         } else {
@@ -21,35 +22,35 @@ module.exports = (robot) => {
     let brainKeep = robot.brain.get('keep') || [];
     let brainProblem = robot.brain.get('problem') || [];
 
-    robot.respond(/k (.*)/i, (res) => {
+    robot.respond(/kpt k (.*)/i, (res) => {
         if (!mode) return false;
 
-        brainKeep.push(res.match[0]);
-        res.send(res.match[0] + 'をKEEPに追加したゴシ！');
+        brainKeep.push(res.match[1]);
+        res.send(`「${res.match[1]}」をKEEPに追加したゴシ！`);
     });
 
-    robot.respond(/p (.*)/i, (res) => {
+    robot.respond(/kpt p (.*)/i, (res) => {
         if (!mode) return false;
 
-        brainProblem.push(res.match[0]);
-        res.send(res.match[0] + 'をPROBLEMに追加したゴシ！');
+        brainProblem.push(res.match[1]);
+        res.send(`「${res.match[1]}」をPROBLEMに追加したゴシ！`);
     });
 
-    robot.respond(/k list/i, (res) => {
+    robot.respond(/kpt list k/i, (res) => {
         if (!mode) return false;
 
         res.send('現在のKEEPはこれだけ出てるゴシよ。');
         brainKeep.forEach(elm => {
-            res.send(':ok_woman:' + elm);
+            res.send(`:ok_woman:「${elm}」`);
         });
     });
 
-    robot.respond(/p list/i, (res) => {
+    robot.respond(/kpt list p/i, (res) => {
         if (!mode) return false;
 
         res.send('現在のPROBLEMはこれだけ出てるゴシよ。');
         brainProblem.forEach(elm => {
-            res.send(':no_good:' + elm);
+            res.send(`:no_good:「${elm}」`);
         });
     });
 

--- a/src/kpt.js
+++ b/src/kpt.js
@@ -7,7 +7,6 @@ module.exports = (robot) => {
     // KPTモードのON/OFF
     let mode = false;
     robot.respond(/kpt mode (.*)/i, (res) => {
-        console.log(res.match[0], res.match[1]);
         if (res.match[1] === 'on') {
             mode = true;
             res.send('KPTモードがONになったゴシ！振り返るゴシ〜！');

--- a/src/kpt.js
+++ b/src/kpt.js
@@ -1,0 +1,64 @@
+/**
+ * KPT
+*/
+
+module.exports = (robot) => {
+
+    // KPTモードのON/OFF
+    let mode = false;
+    robot.respond(/kptmode (.*)/i, (res) => {
+        if (res.match[0] === 'on') {
+            mode = true;
+            res.send('KPTモードがONになったゴシ！振り返るゴシ〜！');
+        } else if (res.match[0] === 'off') {
+            mode = false;
+            res.send('KPTモードがOFFになったゴシ！お疲れ様ゴシ。');
+        } else {
+            res.send('指定が間違ってるゴシ。 `on` か `off` しか受け付けてないゴシ。');
+        }
+    });
+
+    let brainKeep = robot.brain.get('keep') || [];
+    let brainProblem = robot.brain.get('problem') || [];
+
+    robot.respond(/k (.*)/i, (res) => {
+        if (!mode) return false;
+
+        brainKeep.push(res.match[0]);
+        res.send(res.match[0] + 'をKEEPに追加したゴシ！');
+    });
+
+    robot.respond(/p (.*)/i, (res) => {
+        if (!mode) return false;
+
+        brainProblem.push(res.match[0]);
+        res.send(res.match[0] + 'をPROBLEMに追加したゴシ！');
+    });
+
+    robot.respond(/k list/i, (res) => {
+        if (!mode) return false;
+
+        res.send('現在のKEEPはこれだけ出てるゴシよ。');
+        brainKeep.forEach(elm => {
+            res.send(':ok_woman:' + elm);
+        });
+    });
+
+    robot.respond(/p list/i, (res) => {
+        if (!mode) return false;
+
+        res.send('現在のPROBLEMはこれだけ出てるゴシよ。');
+        brainProblem.forEach(elm => {
+            res.send(':no_good:' + elm);
+        });
+    });
+
+    robot.respond(/kpt clear/i, (res) => {
+        if (!mode) return false;
+
+        brainKeep = [];
+        brainProblem = [];
+        res.send('KPTをすべてクリアしたゴシ！！');
+    });
+
+}

--- a/src/kpt.js
+++ b/src/kpt.js
@@ -23,25 +23,25 @@ module.exports = (robot) => {
     let brainProblem = robot.brain.get('problem') || [];
 
     // 追加
-    const addItem = (brain, type, msg) => {
+    const addItem = (res, brain, type, msg) => {
         brain.push(msg);
         res.send(`「${msg}」を${type}に追加したゴシ！`);
     };
     robot.respond(/kpt k (.*)/i, (res) => {
         if (!mode) return false;
-        addItem(brainKeep, 'KEEP', res.match[1]);
+        addItem(res, brainKeep, 'KEEP', res.match[1]);
     });
     robot.respond(/kpt p (.*)/i, (res) => {
         if (!mode) return false;
-        addItem(brainProblem, 'PROBLEM', res.match[1]);
+        addItem(res, brainProblem, 'PROBLEM', res.match[1]);
     });
 
     // 一覧の確認
-    const showList = (brain, type, emoji) => {
+    const showList = (res, brain, type, emoji) => {
         if (brain.length === 0) {
-            res.send('${type}はまだ0件だゴシ…。');
+            res.send(`${type}はまだ0件だゴシ…。`);
         } else {
-            res.send('現在の${type}はこれだけ出てるゴシよ。');
+            res.send(`現在の${type}はこれだけ出てるゴシよ。`);
             brain.forEach(elm => {
                 res.send(`${emoji}「${elm}」`);
             });
@@ -49,11 +49,11 @@ module.exports = (robot) => {
     };
     robot.respond(/kpt list k/i, (res) => {
         if (!mode) return false;
-        showList(brainKeep, 'KEEP', ':ok_woman:');
+        showList(res, brainKeep, 'KEEP', ':ok_woman:');
     });
     robot.respond(/kpt list p/i, (res) => {
         if (!mode) return false;
-        showList(brainProblem, 'PROBLEM', ':no_good:');
+        showList(res, brainProblem, 'PROBLEM', ':no_good:');
     });
 
     // 一覧のクリア

--- a/src/kpt.js
+++ b/src/kpt.js
@@ -39,19 +39,27 @@ module.exports = (robot) => {
     robot.respond(/kpt list k/i, (res) => {
         if (!mode) return false;
 
-        res.send('現在のKEEPはこれだけ出てるゴシよ。');
-        brainKeep.forEach(elm => {
-            res.send(`:ok_woman:「${elm}」`);
-        });
+        if (brainKeep.length === 0) {
+            res.send('KEEPはまだ0件だゴシ…。');
+        } else {
+            res.send('現在のKEEPはこれだけ出てるゴシよ。');
+            brainKeep.forEach(elm => {
+                res.send(`:ok_woman:「${elm}」`);
+            });
+        }
     });
 
     robot.respond(/kpt list p/i, (res) => {
         if (!mode) return false;
 
-        res.send('現在のPROBLEMはこれだけ出てるゴシよ。');
-        brainProblem.forEach(elm => {
-            res.send(`:no_good:「${elm}」`);
-        });
+        if (brainKeep.length === 0) {
+            res.send('PROBLEMはまだ0件だゴシ…。');
+        } else {
+            res.send('現在のPROBLEMはこれだけ出てるゴシよ。');
+            brainProblem.forEach(elm => {
+                res.send(`:no_good:「${elm}」`);
+            });
+        }
     });
 
     robot.respond(/kpt clear/i, (res) => {

--- a/src/kpt.js
+++ b/src/kpt.js
@@ -65,4 +65,19 @@ module.exports = (robot) => {
         res.send('KPTをすべてクリアしたゴシ！！');
     });
 
+    // ヘルプ
+    robot.respond(/kpt help/i, (res) => {
+        res.send(`
+KPT機能を紹介するゴシ！
+
+:arrows_counterclockwise: kpt mode {on|off} - KPT機能を有効にするかを切り替え
+:heavy_plus_sign: kpt k {*} - KEEPを追加
+:heavy_minus_sign: kpt p {*} - PROBLEMを追加
+:bookmark: kpt list {k|p} - 今までに追加したKEEP/PROBLEMを参照
+:boom: kpt clear - 今までに追加したものをすべて削除
+:beginner: kpt help - いま見ているコレ
+
+振り返りが終わったら、clearしてmode offを忘れずにゴシ！
+        `);
+    });
 }


### PR DESCRIPTION
# 実現したかったこと

遠隔でKPT振り返りをする際に、スプレッドシート等を使うことが多いが
オフラインでやる時に比べて、誰がどんなことを書いているかがリアルタイムに見えてしまう。

「◯◯さんが同じの書いてるから、上げなくていいか…」となってしまって
同じ意見がどれくらい出ているかが見えなくなる問題アリ。

遠隔でも各々に意見出し → 簡単にまとめて参照　がしたかった。

# できること

## Keep/Problemの追加

`kpt k あああ`
`kpt p いいい`
botに話すだけで追加可能
まったく別のchannelからでも同じようにできるので、各自がbotにDMで追加可能です。

![ss 2016-12-16 16 15 32](https://cloud.githubusercontent.com/assets/9045135/21254765/f3e9d3f2-c3aa-11e6-9d71-fb536b0fae66.png)

## 一覧の参照

`kpt list k`
`kpt list p`
それぞれ一覧を参照できる

![ss 2016-12-16 16 16 34](https://cloud.githubusercontent.com/assets/9045135/21254776/0aa5207e-c3ab-11e6-9793-4654aa185596.png)

## 機能の有効化切り替え

誤爆を防ぐため、有効時にしか各コマンドは実行できません

`kpt mode on` `kpt mode off`

![ss 2016-12-16 16 18 01](https://cloud.githubusercontent.com/assets/9045135/21254807/3eeb1802-c3ab-11e6-8427-66e4e689e484.png)

## 一覧のクリア

`kpt clear`

追加した項目を一括削除します

![ss 2016-12-16 16 19 06](https://cloud.githubusercontent.com/assets/9045135/21254831/65548c3a-c3ab-11e6-85be-12551baa43cd.png)

## ヘルプ

`kpt help`

使い方がやや複雑なので、コマンドヘルプを備えました
このコマンドのみ、`kpt mode`が`on`になっていなくても反応します

![ss 2016-12-16 16 22 06](https://cloud.githubusercontent.com/assets/9045135/21254882/d2fbcece-c3ab-11e6-9f6f-ce4f366eb345.png)
