### PR TITLE
格納したデータ件数をレスポンスで返す

### DIFF
--- a/src/firebase/index.js
+++ b/src/firebase/index.js
@@ -23,6 +23,13 @@ export const readLength = () => {
         });
 };
 
+export const equalUser = (user: string) => {
+    return getlist.orderByChild('user').equalTo(user).once('value')
+        .then(snapshot => {
+            return snapshot.numChildren();
+        });
+};
+
 export const overCp = (selectCp: number) => {
     return getlist.orderByChild('cp').startAt(selectCp).once('value')
         .then(snapshot => {

--- a/src/firebase/index.js
+++ b/src/firebase/index.js
@@ -17,8 +17,8 @@ export const pushData = (data: Object) => {
 };
 
 export const readLength = () => {
-    const num = getlist.on('value', snapshot => {
-        return snapshot.numChildren();
-    });
-    return num;
+    return getlist.once('value')
+        .then(snapshot => {
+            return snapshot.numChildren();
+        });
 };

--- a/src/firebase/index.js
+++ b/src/firebase/index.js
@@ -23,6 +23,13 @@ export const readLength = () => {
         });
 };
 
+export const readLengthId = (id: number) => {
+    return getlist.orderByChild('id').equalTo(id).once('value')
+        .then(snapshot => {
+            return snapshot.numChildren();
+        });
+};
+
 export const equalUser = (user: string) => {
     return getlist.orderByChild('user').equalTo(user).once('value')
         .then(snapshot => {

--- a/src/firebase/index.js
+++ b/src/firebase/index.js
@@ -22,3 +22,17 @@ export const readLength = () => {
             return snapshot.numChildren();
         });
 };
+
+export const overCp = (selectCp: number) => {
+    return getlist.orderByChild('cp').startAt(selectCp).once('value')
+        .then(snapshot => {
+            return snapshot.numChildren();
+        });
+};
+
+export const equalShiny = () => {
+    return getlist.orderByChild('isShiny').equalTo(true).once('value')
+        .then(snapshot => {
+            return snapshot.numChildren();
+        });
+};

--- a/src/firebase/index.js
+++ b/src/firebase/index.js
@@ -16,6 +16,9 @@ export const pushData = (data: Object) => {
     getlist.push(data);
 };
 
-// getlist.on('value', snapshot => {
-//     console.log(snapshot.val());
-// });
+export const readLength = () => {
+    const num = getlist.on('value', snapshot => {
+        return snapshot.numChildren();
+    });
+    return num;
+};

--- a/src/pokemon.js
+++ b/src/pokemon.js
@@ -43,6 +43,14 @@ module.exports = (robot) => {
                 res.send(libs.getLengthRes(length));
             });
     });
+    robot.respond(/user pokemon (.*)/, (res) => {
+        const user = res.match[1];
+        firebase.equalUser(user)
+            .then(length => {
+                if (length === 0) return false;
+                res.send(`${user}が捕まえたポケモンは${length}匹だゴシ！`);
+            });
+    });
     robot.respond(/overcp pokemon (.*)/, (res) => {
         const selectCp = parseInt(res.match[1]);
         firebase.overCp(selectCp)

--- a/src/pokemon.js
+++ b/src/pokemon.js
@@ -43,4 +43,17 @@ module.exports = (robot) => {
                 res.send(libs.getLengthRes(length));
             });
     });
+    robot.respond(/overcp pokemon (.*)/, (res) => {
+        const selectCp = parseInt(res.match[1]);
+        firebase.overCp(selectCp)
+            .then(length => {
+                res.send(`今までにCP${selectCp}以上のポケモンは${length}匹捕まえたゴシ！`);
+            });
+    });
+    robot.respond(/shiny pokemon/, (res) => {
+        firebase.equalShiny()
+            .then(length => {
+                res.send(`今までに色違いポケモンは${length}匹捕まえたゴシ！`);
+            });
+    });
 };

--- a/src/pokemon.js
+++ b/src/pokemon.js
@@ -6,6 +6,7 @@
 import 'babel-polyfill';
 import fetch from 'node-fetch';
 import * as libs from './pokemon/libs';
+import * as firebase from './firebase/';
 import { MAX, RES } from './pokemon/constants';
 
 module.exports = (robot) => {
@@ -30,14 +31,16 @@ module.exports = (robot) => {
                 res.send(libs.evalPokeCpRes(pokeData.cp));
 
                 const saveData = libs.getSaveData(pokeData, user, isShiny);
-                libs.savePokemon(saveData);
+                firebase.pushData(saveData);
             } catch (err) {
                 res.send(err);
             }
         })();
     });
-    robot.respond(/length pokemon/, (res) => {
-        const length = libs.getPokeLength();
-        res.send(`${length}匹捕まえたゴシ！`);
+    robot.respond(/zukan pokemon/, (res) => {
+        firebase.readLength()
+            .then(length => {
+                res.send(libs.getLengthRes(length));
+            });
     });
 };

--- a/src/pokemon.js
+++ b/src/pokemon.js
@@ -64,4 +64,9 @@ module.exports = (robot) => {
                 res.send(`今までに色違いポケモンは${length}匹捕まえたゴシ！`);
             });
     });
+
+    // Help Command
+    robot.respond(/h pokemon/, (res) => {
+        res.send(RES.help);
+    });
 };

--- a/src/pokemon.js
+++ b/src/pokemon.js
@@ -36,4 +36,8 @@ module.exports = (robot) => {
             }
         })();
     });
+    robot.respond(/length pokemon/, (res) => {
+        const length = libs.getPokeLength();
+        res.send(`${length}匹捕まえたゴシ！`);
+    });
 };

--- a/src/pokemon.js
+++ b/src/pokemon.js
@@ -62,20 +62,20 @@ module.exports = (robot) => {
         firebase.equalUser(user)
             .then(length => {
                 if (length === 0) return false;
-                res.send(`${user}が捕まえたポケモンは${length}匹だゴシ！`);
+                res.send(libs.getLengthUserRes(length, user));
             });
     });
     robot.respond(/overcp pokemon (.*)/, (res) => {
         const selectCp = parseInt(res.match[1]);
         firebase.overCp(selectCp)
             .then(length => {
-                res.send(`今までにCP${selectCp}以上のポケモンは${length}匹捕まえたゴシ！`);
+                res.send(libs.getLengthOvercpRes(length, selectCp));
             });
     });
     robot.respond(/shiny pokemon/, (res) => {
         firebase.equalShiny()
             .then(length => {
-                res.send(`今までに色違いポケモンは${length}匹捕まえたゴシ！`);
+                res.send(libs.getLengthShinyRes(length));
             });
     });
 

--- a/src/pokemon.js
+++ b/src/pokemon.js
@@ -38,9 +38,23 @@ module.exports = (robot) => {
         })();
     });
     robot.respond(/zukan pokemon/, (res) => {
+        // 入力値に数値が付与されていたら処理しない
+        const input = res.message.text;
+        if (input !== 'togoshi-bot zukan pokemon') return false;
+
         firebase.readLength()
             .then(length => {
                 res.send(libs.getLengthRes(length));
+            });
+    });
+    robot.respond(/zukan pokemon (.*)/, (res) => {
+        // 0指定の場合は処理しない
+        const id = parseInt(res.match[1]);
+        if (id === 0) return false;
+
+        firebase.readLengthId(id)
+            .then(length => {
+                res.send(libs.getLengthIdRes(length, id));
             });
     });
     robot.respond(/user pokemon (.*)/, (res) => {

--- a/src/pokemon/constants.js
+++ b/src/pokemon/constants.js
@@ -40,6 +40,7 @@ export const RES = {
     help: `
 :heavy_check_mark: \`get pokemon\` : ポケモンを1匹捕まえます
 :heavy_check_mark: \`zukan pokemon\` : 今までに捕まえたポケモンの総数を表示
+:heavy_check_mark: \`zukan pokemon {id: number}\` : 指定のIDの捕まえたポケモンの数を表示
 :heavy_check_mark: \`user pokemon {username: string}\` : 指定のusernameが捕まえたポケモンの数を表示
 :heavy_check_mark: \`overcp pokemon {cp: number}\` : 指定したCPよりも強いポケモンの数を表示
 :heavy_check_mark: \`shiny pokemon\` : 今までに捕まえた色違いポケモンの数を表示

--- a/src/pokemon/constants.js
+++ b/src/pokemon/constants.js
@@ -36,5 +36,12 @@ export const RES = {
     weakest: 'コイツは超絶孤高によわすぎるゴシ…。',
     go: ':pokeball: 捕まえてくるゴシ。。。。。',
     miss: '捕まえるの失敗したゴシ…。',
-    shiny: '色違いを捕まえたゴシィィィ！！！？'
+    shiny: '色違いを捕まえたゴシィィィ！！！？',
+    help: `
+:heavy_check_mark: \`get pokemon\` : ポケモンを1匹捕まえます
+:heavy_check_mark: \`zukan pokemon\` : 今までに捕まえたポケモンの総数を表示
+:heavy_check_mark: \`user pokemon {username: string}\` : 指定のusernameが捕まえたポケモンの数を表示
+:heavy_check_mark: \`overcp pokemon {cp: number}\` : 指定したCPよりも強いポケモンの数を表示
+:heavy_check_mark: \`shiny pokemon\` : 今までに捕まえた色違いポケモンの数を表示
+    `
 };

--- a/src/pokemon/libs.js
+++ b/src/pokemon/libs.js
@@ -54,6 +54,11 @@ export const getLengthRes = (length: number): string => {
     return `全部で${length}匹捕まえたゴシ！`;
 };
 
+export const getLengthIdRes = (length: number, id: number): string => {
+    const name = translateData[id - 1].ja
+    return `${name}はこれまでに${length}匹捕まえたゴシ！`;
+};
+
 export const evalPokeCpRes = (cp: number): ?string => {
     for (let [key, val] of Object.entries(STRENGTH)) {
         // flow-disable-line // val as mixed. https://github.com/facebook/flow/issues/2221

--- a/src/pokemon/libs.js
+++ b/src/pokemon/libs.js
@@ -42,12 +42,14 @@ export const getPokeData = ({ id, name }: Object, isShiny: boolean = false): Obj
     };
 };
 
-export const getSuccessRes = (data: Object): string => {
-    return `CP${data.cp}の${data.name}を捕まえたゴシ！\n${data.img}`;
+export const getSaveData = ({ id, cp }: Object, user: string, isShiny: boolean = false) => {
+    const time = format(new Date(), 'YYYY-MM-DDTHH:mm:ssZ');
+    return { id, user, time, cp, isShiny };
 };
 
-export const getShinyRes = (isShiny: boolean = false): string => {
-    return isShiny ? RES.shiny : '';
+// Response Message
+export const getSuccessRes = (data: Object): string => {
+    return `CP${data.cp}の${data.name}を捕まえたゴシ！\n${data.img}`;
 };
 
 export const getLengthRes = (length: number): string => {
@@ -59,14 +61,25 @@ export const getLengthIdRes = (length: number, id: number): string => {
     return `${name}はこれまでに${length}匹捕まえたゴシ！`;
 };
 
+export const getLengthUserRes = (length: number, user: string): string => {
+    return `${user}が捕まえたポケモンは${length}匹だゴシ！`;
+};
+
+export const getLengthOvercpRes = (length: number, selectCp: number): string => {
+    return `今までにCP${selectCp}以上のポケモンは${length}匹捕まえたゴシ！`;
+};
+
+export const getLengthShinyRes = (length: number): string => {
+    return `今までに色違いポケモンは${length}匹捕まえたゴシ！`;
+};
+
+export const getShinyRes = (isShiny: boolean = false): string => {
+    return isShiny ? RES.shiny : '';
+};
+
 export const evalPokeCpRes = (cp: number): ?string => {
     for (let [key, val] of Object.entries(STRENGTH)) {
         // flow-disable-line // val as mixed. https://github.com/facebook/flow/issues/2221
         if (cp >= val) return RES[key];
     }
-};
-
-export const getSaveData = ({ id, cp }: Object, user: string, isShiny: boolean = false) => {
-    const time = format(new Date(), 'YYYY-MM-DDTHH:mm:ssZ');
-    return { id, user, time, cp, isShiny };
 };

--- a/src/pokemon/libs.js
+++ b/src/pokemon/libs.js
@@ -66,3 +66,7 @@ export const getSaveData = ({ id, cp }: Object, user: string, isShiny: boolean =
 export const savePokemon = (saveData: Object) => {
     firebase.pushData(saveData);
 };
+
+export const getPokeLength = (saveData: Object) => {
+    return firebase.readLength();
+};

--- a/src/pokemon/libs.js
+++ b/src/pokemon/libs.js
@@ -57,7 +57,7 @@ export const getLengthRes = (length: number): string => {
 };
 
 export const getLengthIdRes = (length: number, id: number): string => {
-    const name = translateData[id - 1].ja
+    const name = translateData[id - 1].ja;
     return `${name}はこれまでに${length}匹捕まえたゴシ！`;
 };
 

--- a/src/pokemon/libs.js
+++ b/src/pokemon/libs.js
@@ -2,7 +2,6 @@
 
 import { format } from 'date-fns';
 import translateData from '../../data/pokemon.json';
-import * as firebase from '../firebase/';
 import {
     MAXCP,
     STRENGTH,
@@ -51,6 +50,10 @@ export const getShinyRes = (isShiny: boolean = false): string => {
     return isShiny ? RES.shiny : '';
 };
 
+export const getLengthRes = (length: number): string => {
+    return `全部で${length}匹捕まえたゴシ！`;
+};
+
 export const evalPokeCpRes = (cp: number): ?string => {
     for (let [key, val] of Object.entries(STRENGTH)) {
         // flow-disable-line // val as mixed. https://github.com/facebook/flow/issues/2221
@@ -61,12 +64,4 @@ export const evalPokeCpRes = (cp: number): ?string => {
 export const getSaveData = ({ id, cp }: Object, user: string, isShiny: boolean = false) => {
     const time = format(new Date(), 'YYYY-MM-DDTHH:mm:ssZ');
     return { id, user, time, cp, isShiny };
-};
-
-export const savePokemon = (saveData: Object) => {
-    firebase.pushData(saveData);
-};
-
-export const getPokeLength = (saveData: Object) => {
-    return firebase.readLength();
 };


### PR DESCRIPTION
https://github.com/usagi-f/togoshi-bot/pull/28
上記PRでデータの格納はできたので、それを取得したい

## やったこと

以下のコマンドを追加

:heavy_check_mark: `get pokemon` : ポケモンを1匹捕まえます
:heavy_check_mark: `zukan pokemon` : 今までに捕まえたポケモンの総数を表示
:heavy_check_mark: `zukan pokemon {id: number}` : 指定のIDの捕まえたポケモンの数を表示
:heavy_check_mark: `user pokemon {username: string}` : 指定のusernameが捕まえたポケモンの数を表示
:heavy_check_mark: `overcp pokemon {cp: number}` : 指定したCPよりも強いポケモンの数を表示
:heavy_check_mark: `shiny pokemon` : 今までに捕まえた色違いポケモンの数を表示

上記コマンドを教えてくれるヘルプコマンドも追加
:heavy_check_mark: `h pokemon`

---

`firebase/index.js` に各条件のデータ件数を返すメソッドを追加。
条件にあった件数の数値を取得できるPromiseを返します。

## スクリーンショット

![image](https://user-images.githubusercontent.com/9045135/28535563-cf6bbd28-70df-11e7-8a73-28824504afa8.png)

![image](https://user-images.githubusercontent.com/9045135/28535571-d7258fc6-70df-11e7-9425-2ba121b71abd.png)

## 関連Issue
https://github.com/usagi-f/togoshi-bot/issues/2
https://github.com/usagi-f/togoshi-bot/issues/11