### PR TITLE
コマンドの仕様が変わったためhelpも修正

### DIFF
--- a/src/pokemon/constants.js
+++ b/src/pokemon/constants.js
@@ -40,7 +40,7 @@ export const RES = {
     help: `
 :heavy_check_mark: \`get pokemon\` : ポケモンを1匹捕まえます
 :heavy_check_mark: \`zukan pokemon\` : 今までに捕まえたポケモンの総数を表示
-:heavy_check_mark: \`zukan pokemon {id: number}\` : 指定のIDの捕まえたポケモンの数を表示
+:heavy_check_mark: \`zukan pokemon {name: string}\` : 指定の日本語名の捕まえたポケモンの数を表示
 :heavy_check_mark: \`user pokemon {username: string}\` : 指定のusernameが捕まえたポケモンの数を表示
 :heavy_check_mark: \`overcp pokemon {cp: number}\` : 指定したCPよりも強いポケモンの数を表示
 :heavy_check_mark: \`shiny pokemon\` : 今までに捕まえた色違いポケモンの数を表示


### PR DESCRIPTION
https://github.com/usagi-f/togoshi-bot/pull/40
上記PRで `zukan pokemon {id}` から `zukan pokemon {name}` に仕様変更があったが、ヘルプコマンドで表示する文章の修正が漏れていた