### PR TITLE
update: 捕まえた匹数が0の時に何も起こらないバグを修正

### DIFF
--- a/src/pokemon.js
+++ b/src/pokemon.js
@@ -52,7 +52,6 @@ module.exports = (robot) => {
         const user = res.match[1];
         firebase.equalUser(user)
             .then(length => {
-                if (length === 0) return false;
                 res.send(libs.getLengthUserRes(length, user));
             });
     });

--- a/test/pokemon.spec.js
+++ b/test/pokemon.spec.js
@@ -2,41 +2,72 @@ import assert from 'assert';
 import proxyquire from 'proxyquire';
 
 describe('pokemon.js', () => {
-    // ダミーデータ（共通）
-    const dummyCommon = {
-        './pokemon/get-pokemon': {
-            default: class GetPokemon {
-                getSaveData () { return {}; }
-                getSuccessRes () { return '成功したゴシ'; }
+    let dummyCommon;
+    let robot;
+    let res;
+    beforeEach(() => {
+        // ダミーデータ（共通）
+        dummyCommon = {
+            './pokemon/get-pokemon': {
+                default: class GetPokemon {
+                    getSaveData () { return {}; }
+                    getSuccessRes () { return '成功したゴシ'; }
+                }
+            },
+            './pokemon/libs': {
+                getRandomUrl: () => {},
+                getLengthRes: (length) => { return `${length}匹ゴシ！`; },
+                getLengthNameRes: (length, name) => { return `${name}は${length}匹ゴシ！`; },
+                getLengthUserRes: (length, user) => { return `${user}は${length}匹ゴシ！！`; },
+                getLengthOvercpRes: (length, selectCp) => { return `${selectCp}以上は${length}匹ゴシ！`; },
+                getLengthShinyRes: (length) => { return `色違いは${length}匹ゴシ！`; }
+            },
+            './firebase/': {
+                pushData: () => {},
+                readLength: () => {
+                    return new Promise(resolve => { resolve(0); });
+                },
+                readLengthName: () => {
+                    return new Promise(resolve => { resolve(0); });
+                },
+                equalUser: () => {
+                    return new Promise(resolve => { resolve(0); });
+                },
+                overCp: () => {
+                    return new Promise(resolve => { resolve(0); });
+                },
+                equalShiny: () => {
+                    return new Promise(resolve => { resolve(0); });
+                }
+            },
+            './pokemon/constants': {
+                RES: {
+                    go: '捕まえてくるゴシ',
+                    miss: '失敗したゴシ',
+                    help: 'helpゴシ'
+                }
             }
-        },
-        './firebase/': { pushData: () => {} },
-        './pokemon/constants': {
-            RES: {
-                go: '捕まえてくるゴシ',
-                miss: '失敗したゴシ'
+        };
+        // ダミーrobot
+        robot = {
+            respond: (pattern, func) => {
+                robot[new RegExp(pattern)] = func;
             }
-        }
-    };
-    // ダミーrobot
-    const robot = {
-        respond: (pattern, func) => {
-            robot[new RegExp(pattern)] = func;
-        }
-    };
-    // ダミーres
-    const res = {
-        message: {
-            user: {
-                name: 'admin'
+        };
+        // ダミーres
+        res = {
+            message: {
+                user: {
+                    name: 'admin'
+                }
+            },
+            messages: [],
+            send: (message) => {
+                // 検証用にmessageを格納
+                res.messages.push(message);
             }
-        },
-        messages: [],
-        send: (message) => {
-            // 検証用にmessageを格納
-            res.messages.push(message);
-        }
-    };
+        };
+    });
 
     it('get pokemonが正しく処理される（正常系）', async () => {
         // ダミーデータ（正常系）
@@ -58,6 +89,7 @@ describe('pokemon.js', () => {
 
         assert.equal(res.messages[0], '捕まえてくるゴシ');
         assert.equal(res.messages[1], '成功したゴシ');
+        assert.equal(typeof res.messages[2], 'undefined');
     });
 
     it('get pokemonが正しく処理される（異常系）', async () => {
@@ -81,5 +113,78 @@ describe('pokemon.js', () => {
         assert.equal(res.messages[0], '捕まえてくるゴシ');
         assert.equal(res.messages[1], '失敗したゴシ');
         assert.equal(typeof res.messages[2], 'undefined');
+    });
+
+    it('zukan pokemonが正しく処理される', async () => {
+        // pokemon.js内のimportをダミーに差し替え
+        proxyquire('../src/pokemon', dummyCommon)(robot);
+        // zukan pokemon呼び出し
+        res.message.text = 'togoshi-bot zukan pokemon';
+        res.messages = [];
+        await robot['/zukan pokemon/'](res);
+        res.message.text = '@togoshi-bot zukan pokemon';
+        await robot['/zukan pokemon/'](res);
+
+        assert.equal(res.messages[0], '0匹ゴシ！');
+        assert.equal(res.messages[1], '0匹ゴシ！');
+        assert.equal(typeof res.messages[2], 'undefined');
+    });
+
+    it('zukan pokemon (.*)が正しく処理される', async () => {
+        // pokemon.js内のimportをダミーに差し替え
+        proxyquire('../src/pokemon', dummyCommon)(robot);
+        // zukan pokemon呼び出し
+        res.match = [null, 'フシギダネ'];
+        res.messages = [];
+        await robot['/zukan pokemon (.*)/'](res);
+
+        assert.equal(res.messages[0], 'フシギダネは0匹ゴシ！');
+        assert.equal(typeof res.messages[1], 'undefined');
+    });
+
+    it('user pokemon (.*)が正しく処理される', async () => {
+        // pokemon.js内のimportをダミーに差し替え
+        proxyquire('../src/pokemon', dummyCommon)(robot);
+        // user pokemon呼び出し
+        res.match = [null, 'admin'];
+        res.messages = [];
+        await robot['/user pokemon (.*)/'](res);
+
+        assert.equal(res.messages[0], 'adminは0匹ゴシ！！');
+        assert.equal(typeof res.messages[1], 'undefined');
+    });
+
+    it('overcp pokemon (.*)が正しく処理される', async () => {
+        // pokemon.js内のimportをダミーに差し替え
+        proxyquire('../src/pokemon', dummyCommon)(robot);
+        // overcp pokemon呼び出し
+        res.match = [null, '1000'];
+        res.messages = [];
+        await robot['/overcp pokemon (.*)/'](res);
+
+        assert.equal(res.messages[0], '1000以上は0匹ゴシ！');
+        assert.equal(typeof res.messages[1], 'undefined');
+    });
+
+    it('shiny pokemonが正しく処理される', async () => {
+        // pokemon.js内のimportをダミーに差し替え
+        proxyquire('../src/pokemon', dummyCommon)(robot);
+        // shiny pokemon呼び出し
+        res.messages = [];
+        await robot['/shiny pokemon/'](res);
+
+        assert.equal(res.messages[0], '色違いは0匹ゴシ！');
+        assert.equal(typeof res.messages[1], 'undefined');
+    });
+
+    it('h pokemonが正しく処理される', async () => {
+        // pokemon.js内のimportをダミーに差し替え
+        proxyquire('../src/pokemon', dummyCommon)(robot);
+        // h pokemon呼び出し
+        res.messages = [];
+        await robot['/h pokemon/'](res);
+
+        assert.equal(res.messages[0], 'helpゴシ');
+        assert.equal(typeof res.messages[1], 'undefined');
     });
 });


### PR DESCRIPTION
#46 
# やったこと
pokemon.js内のuser pokemonメソッド内、
`if (length === 0) return false;`
を削除しlengthが0でもres.sendされるように修正。

あわせて、pokemon.spec.jsに以下のテストケースを追加
- zukan pokemon
- user pokemon
- overcp pokemon
- shiny pokemon
- h pokemon